### PR TITLE
add a version of the SPE-1 problem that tests the thermal features

### DIFF
--- a/spe1_thermal/README
+++ b/spe1_thermal/README
@@ -1,0 +1,16 @@
+This directory contains the input data file for a version of the SPE-1
+[1] problem which has been modified to include thermal effects. The
+intention of it is to test the "pseudo-thermal" features of the OPM
+simulators. For this reason, the dataset will probably produce errors
+or incorrect results if using an ECLiPSE simulator.
+
+The ownership of the copyright of this dataset is unclear: Some parts
+seem to be written by Schlumberger [2], which in turn seem to be
+modified by Jon Kleppe of NTNU [3] and some (mainly saturation
+function related) data seems to be calculated by SINTEF using MRST.
+Finally some modifications where done by Ove Savareid and Andreas
+Lauser in the context of the OPM project.
+
+[1] http://www.spe.org/web/csp/datasets/set01.htm
+[2] http://slb.com
+[3] http://www.ipt.ntnu.no/~kleppe/TPG4160/ex3/ODEH.DATA

--- a/spe1_thermal/SPE1_THERMAL.DATA
+++ b/spe1_thermal/SPE1_THERMAL.DATA
@@ -1,0 +1,592 @@
+-- =====================================================================
+-- THIS IS THE FIRST SPE COMPARISON PROBLEM,"COMPARISON OF SOLUTIONS TO A
+-- THREE-DIMENSIONAL BLACK-OIL RESERVOIR SIMULATION PROBLEM", REPORTED
+-- BY AZIS AND ODEH AT THE SPE SYMPOSIUM ON RESERVOIR SIMULATION ,
+-- JANUARY 1981. IT IS  A NON SWELLING AND SWELLING STUDY. A REGULAR
+-- GRID WITH TWO WELLS (INJECTOR AND PRODUCER)AND A IMPES SOLUTION METHOD
+-- IS USED FOR THIS SIMULATION.THE PRODUCTION IS CONTROLLED BY FLOW RATE
+-- AND MIN. BHP. OIL RATE, GOR, PRESSURE AND GAS SATURATION ARE TO BE REPORTED.
+-- =====================================================================
+RUNSPEC
+-- TITLE
+--   ODEH PROBLEM - IMPLICIT OPTION - 1200 DAYS /
+
+DIMENS
+   10   10    3  /
+
+NONNC
+
+OIL
+
+WATER
+
+GAS
+
+DISGAS
+
+FIELD
+
+EQLDIMS
+    1  100   10    1    1 /
+
+TABDIMS
+    1    1   17   12    1   12 /
+
+WELLDIMS
+    2    1    1    2 /
+
+NUPCOL
+    4 /
+
+START
+  19 'OCT' 1982  /
+
+NSTACK
+   24 /
+
+--FMTOUT
+
+--FMTIN
+
+UNIFOUT
+
+UNIFIN
+
+--NOSIM
+
+--IMPES
+
+-------------------------------------------------
+-- Thermal stuff in the RUNSPEC section
+-------------------------------------------------
+
+-- enable the "temperature option"
+TEMP
+
+-- tell the simulator that we have two hydrocarbon components, oil
+-- (first component) and gas (second)
+COMPS
+2 /
+
+OCOMPIDX
+1 /
+
+GCOMPIDX
+2 /
+
+GRID    ================================================================
+-------- IN THIS SECTION , THE GEOMETRY OF THE  SIMULATION GRID AND THE
+-------- ROCK PERMEABILITIES AND POROSITIES ARE DEFINED.
+------------------------------------------------------------------------
+--  THE X AND Y DIRECTION CELL SIZES ( DX, DY ) AND THE POROSITIES ARE
+--  CONSTANT THROUGHOUT THE GRID. THESE ARE SET IN THE FIRST 3 LINES
+--  AFTER THE EQUALS KEYWORD. THE CELL THICKNESSES ( DZ ) AND
+--  PERMEABILITES ARE THEN SET FOR EACH  LAYER. THE CELL TOP DEPTHS
+--  ( TOPS ) ARE NEEDED ONLY IN THE TOP LAYER ( THOUGH THEY COULD BE.
+--  SET THROUGHOUT THE GRID ). THE SPECIFIED MULTZ VALUES ACT AS
+--  MULTIPLIERS ON THE TRANSMISSIBILITIES BETWEEN THE CURRENT LAYER
+--  AND THE LAYER BELOW.
+
+DXV
+10*1000.0
+/
+
+DYV
+10*1000.0
+/
+
+DZ
+100*20.0 100*30.0 100*50.0
+/
+
+PORO
+300*0.3
+/
+
+PERMX
+100*500.0
+100*50.0
+100*200.0
+/
+
+PERMY
+100*500.0
+100*50.0
+100*200.0
+/
+
+-- Note: ignoring  MULTZ!
+--   layer 1-2    'MULTZ' 0.64      /
+--   layer 2-3    'MULTZ' 0.265625  /
+-- Reducing PERMZ a little instead
+PERMZ
+100*300.0
+100*30.0
+100*50.0
+/
+
+
+TOPS
+100*8325.0
+/
+
+
+INIT
+
+
+PROPS    ===============================================================
+-------- THE PROPS SECTION DEFINES THE REL. PERMEABILITIES, CAPILLARY
+-------- PRESSURES, AND THE PVT PROPERTIES OF THE RESERVOIR FLUIDS
+
+----------------------------------------------------------------------
+-- WATER RELATIVE PERMEABILITY AND CAPILLARY PRESSURE ARE TABULATED AS
+-- A FUNCTION OF WATER SATURATION.
+--
+-- Generated with MRST's family_1() function from the original deck.
+--  SWAT   KRW   KRO   PCOW
+SWOF
+   0.120000000000000                   0   1.000000000000000                   0
+   0.121000000000000   0.000000011363636   1.000000000000000                   0
+   0.140000000000000   0.000000227272727   0.997000000000000                   0
+   0.170000000000000   0.000000568181818   0.980000000000000                   0
+   0.240000000000000   0.000001363636364   0.700000000000000                   0
+   0.319999999000000   0.000002272727261   0.350000004375000                   0
+   0.370000000000000   0.000002840909091   0.200000000000000                   0
+   0.420000000000000   0.000003409090909   0.090000000000000                   0
+   0.520000000000000   0.000004545454545   0.021000000000000                   0
+   0.570000000000000   0.000005113636364   0.010000000000000                   0
+   0.620000000000000   0.000005681818182   0.001000000000000                   0
+   0.720000000000000   0.000006818181818   0.000100000000000                   0
+   0.820000000000000   0.000007954545455   0.000000000000000                   0
+   1.000000000000000   0.000010000000000                   0                   0
+/
+
+
+SGOF
+                   0                   0   1.000000000000000                   0
+   0.001000000000000                   0   1.000000000000000                   0
+   0.020000000000000                   0   0.997000000000000                   0
+   0.050000000000000   0.005000000000000   0.980000000000000                   0
+   0.120000000000000   0.025000000000000   0.700000000000000                   0
+   0.199999999000000   0.074999999375000   0.350000004375000                   0
+   0.200001100000000   0.075000000000000   0.350000000000000                   0
+   0.250000000000000   0.125000000000000   0.200000000000000                   0
+   0.300000000000000   0.190000000000000   0.090000000000000                   0
+   0.400000000000000   0.410000000000000   0.021000000000000                   0
+   0.449999999000000   0.599999996200000   0.010000000220000                   0
+   0.450001100000000   0.600000000000000   0.010000000000000                   0
+   0.500000000000000   0.720000000000000   0.001000000000000                   0
+   0.600000000000000   0.870000000000000   0.000100000000000                   0
+   0.700000000000000   0.940000000000000                   0                   0
+   0.850000000000000   0.980000000000000                   0                   0
+   0.880000000000000   0.984000000000000                   0                   0
+/
+
+-- PVT PROPERTIES OF WATER
+--
+--    REF. PRES. REF. FVF  COMPRESSIBILITY  REF VISCOSITY  VISCOSIBILITY
+PVTW
+       4014.7     1.029        3.13E-6           0.31            0 /
+
+-- ROCK COMPRESSIBILITY
+--
+--    REF. PRES   COMPRESSIBILITY
+ROCK
+        14.7          3.0E-6          /
+
+-- SURFACE DENSITIES OF RESERVOIR FLUIDS
+--
+--        OIL   WATER   GAS
+DENSITY
+         49.1   64.79  0.06054  /
+
+-- PVT PROPERTIES OF DRY GAS (NO VAPOURISED OIL)
+-- WE WOULD USE PVTG TO SPECIFY THE PROPERTIES OF WET GAS
+--
+--   PGAS   BGAS   VISGAS
+PVDG
+     14.7 166.666   0.008
+    264.7  12.093   0.0096
+    514.7   6.274   0.0112
+   1014.7   3.197   0.014
+   2014.7   1.614   0.0189
+   2514.7   1.294   0.0208
+   3014.7   1.080   0.0228
+   4014.7   0.811   0.0268
+   5014.7   0.649   0.0309
+   9014.7   0.386   0.047   /
+
+-- PVT PROPERTIES OF LIVE OIL (WITH DISSOLVED GAS)
+-- WE WOULD USE PVDO TO SPECIFY THE PROPERTIES OF DEAD OIL
+--
+-- FOR EACH VALUE OF RS THE SATURATION PRESSURE, FVF AND VISCOSITY
+-- ARE SPECIFIED. FOR RS=1.27 AND 1.618, THE FVF AND VISCOSITY OF
+-- UNDERSATURATED OIL ARE DEFINED AS A FUNCTION OF PRESSURE. DATA
+-- FOR UNDERSATURATED OIL MAY BE SUPPLIED FOR ANY RS, BUT MUST BE
+-- SUPPLIED FOR THE HIGHEST RS (1.618).
+--
+--   RS      POIL  FVFO  VISO
+-- PVTO
+--     0.001    14.7 1.062  1.04    /
+--     0.0905  264.7 1.15   0.975   /
+--     0.18    514.7 1.207  0.91    /
+--     0.371  1014.7 1.295  0.83    /
+--     0.636  2014.7 1.435  0.695   /
+--     0.775  2514.7 1.5    0.641   /
+--     0.93   3014.7 1.565  0.594   /
+--     1.270  4014.7 1.695  0.51
+--            5014.7 1.671  0.549
+--            9014.7 1.579  0.74    /
+--     1.618  5014.7 1.827  0.449
+--            9014.7 1.726  0.605   /
+-- /
+PVTO
+1.0000000000e-03
+1.4700000000e+01 1.0620000000e+00 1.0400000000e+00
+1.0147000000e+03 1.0469628319e+00 1.1195294118e+00
+5.0147000000e+03 9.8932035398e-01 1.5090196078e+00
+/
+9.0500000000e-02
+2.6470000000e+02 1.1500000000e+00 9.7500000000e-01
+1.2647000000e+03 1.1337168142e+00 1.0495588235e+00
+5.2647000000e+03 1.0712979351e+00 1.4147058824e+00
+/
+1.8000000000e-01
+5.1470000000e+02 1.2070000000e+00 9.1000000000e-01
+1.5147000000e+03 1.1899097345e+00 9.7958823529e-01
+5.5147000000e+03 1.1243970501e+00 1.3203921569e+00
+/
+3.7100000000e-01
+1.0147000000e+03 1.2950000000e+00 8.3000000000e-01
+2.0147000000e+03 1.2766637168e+00 8.9347058824e-01
+6.0147000000e+03 1.2063746313e+00 1.2043137255e+00
+/
+6.3600000000e-01
+2.0147000000e+03 1.4350000000e+00 6.9500000000e-01
+3.0147000000e+03 1.4146814159e+00 7.4814705882e-01
+7.0147000000e+03 1.3367935103e+00 1.0084313725e+00
+/
+7.7500000000e-01
+2.5147000000e+03 1.5000000000e+00 6.4100000000e-01
+3.5147000000e+03 1.4787610619e+00 6.9001764706e-01
+7.5147000000e+03 1.3973451327e+00 9.3007843137e-01
+/
+9.3000000000e-01
+3.0147000000e+03 1.5650000000e+00 5.9400000000e-01
+4.0147000000e+03 1.5428407080e+00 6.3942352941e-01
+8.0147000000e+03 1.4578967552e+00 8.6188235294e-01
+/
+1.2700000000e+00
+4.0147000000e+03 1.6950000000e+00 5.1000000000e-01
+5.0147000000e+03 1.6710000000e+00 5.4900000000e-01
+9.0147000000e+03 1.5790000000e+00 7.4000000000e-01
+/
+1.6180000000e+00
+5.0147000000e+03 1.8270000000e+00 4.4900000000e-01
+9.0147000000e+03 1.7260000000e+00 6.0500000000e-01
+/
+/
+
+-- OUTPUT CONTROLS FOR PROPS DATA
+-- ACTIVATED FOR SOF3, SWFN, SGFN, PVTW, PVDG, DENSITY AND ROCK KEYWORDS
+RPTPROPS
+1  1  1  0  1  1  1  1  /
+
+-------------------------------------------------
+-- Thermal stuff in the PROPS section
+-------------------------------------------------
+
+-- compressibility of the components in the oil phase
+CREF
+-- c^O_g   c^G_g
+    1e-6       0 /
+
+-- the reservoir reference temperature
+TREF
+-- T^O      T^G
+   554.67 554.67 /
+
+-- the reservoir reference pressure
+PREF
+-- p^O       p^G
+   4790.0 4790.0 /
+
+-- temperature dependence of the water density
+WATDENT
+-- Tref   c_cT1   c_cT2
+   554.67    1*      1* /
+
+-- temperature dependence of the oil density
+THERMEX1
+-- c_T1oil c_T1gas
+      0.0     0.0 /
+
+-- reference conditions for the viscosity tables
+VISCREF
+-- p  Rs
+4790  0.0 /
+
+-- temperature dependence of the water viscosity
+WATVISCT
+-- T      mu_w
+   59.0   0.6
+   95.0   0.31
+   150.0  0.25 /
+
+-- temperature dependence of the oil viscosity
+OILVISCT
+-- T      mu_o
+   59.0   1.7
+   95.0   1.5
+   150.0  1.3 /
+
+-- temperature dependence of the component viscosity in the gas phase
+GASVISCT
+-- T      mu^O_g   mu^G_g
+   59.0      0.0   0.0150
+   95.0      0.0   0.0230
+   150.0     0.0   0.0300 /
+
+
+SOLUTION ===============================================================
+-------- THE SOLUTION SECTION DEFINES THE INITIAL STATE OF THE SOLUTION
+-------- VARIABLES (PHASE PRESSURES, SATURATIONS AND GAS-OIL RATIOS)
+------------------------------------------------------------------------
+-- DATA FOR INITIALISING FLUIDS TO POTENTIAL EQUILIBRIUM
+--
+--    DATUM  DATUM   OWC    OWC    GOC    GOC    RSVD   RVVD   SOLN
+--    DEPTH  PRESS  DEPTH   PCOW  DEPTH   PCOG  TABLE  TABLE   METH
+-- EQUIL
+--        8400   4800   8500    0     8200    0      1      0       0  /
+
+-- VARIATION OF INITIAL RS WITH DEPTH
+--
+--    DEPTH    RS
+-- RSVD
+--        8200  1.270
+--        8500  1.270  /
+
+-- PRESSURE
+-- 100*3.297832774859256e7
+-- 100*3.302313357125603e7
+-- 100*3.309483500720813e7
+-- /
+PRESSURE
+100*4783.10205078125
+100*4789.60058593750
+100*4800.00000000000
+/
+
+SWAT
+300*0.12
+/
+
+SGAS
+300*0.0
+/
+
+-- RS
+-- 300*226.1966570852417
+-- /
+RS
+300*1.27
+/
+
+-- OUTPUT CONTROLS (SWITCH ON OUTPUT OF INITIAL GRID BLOCK PRESSURES)
+RPTSOL
+   RESTART=2 PRES DENW DENO DENG  POIL PGAS PWAT VOIL VGAS VWAT KRO KRG KRW RSSAT /
+--   RESTART=2 DENSO DENSG DENSW POIL PGAS PWAR VOIL VGAS VWAT KRO KRG KRW RSSAT /
+
+-------------------------------------------------
+-- Thermal stuff in the SOLUTION section
+-------------------------------------------------
+
+-- set the temperature of the reservoir
+EQUALS
+TEMPI 95 /
+/
+
+-- increase the temperature around the injector
+BOX
+1 3
+1 3
+1 3
+/
+
+ADD
+TEMPI 50 /
+/
+
+ENDBOX
+/
+
+SUMMARY  ===============================================================
+-------- THIS SECTION SPECIFIES DATA TO BE WRITTEN TO THE SUMMARY FILES
+-------- AND WHICH MAY LATER BE USED WITH THE ECLIPSE GRAPHICS PACKAGE
+------------------------------------------------------------------------
+
+EXCEL
+
+SEPARATE
+
+--REQUEST PRINTED OUTPUT OF SUMMARY FILE DATA
+
+RUNSUM
+
+-- FIELD OIL PRODUCTION
+FOPR
+
+-- WELL GAS-OIL RATIO FOR PRODUCER
+WGOR
+-- 'PRODUCER'
+/
+-- WELL BOTTOM-HOLE PRESSURE
+WBHP
+-- 'PRODUCER'
+/
+
+-- GAS AND OIL SATURATIONS IN INJECTION AND PRODUCTION CELL
+BGSAT
+10 10 3 /
+1  1  1 /
+/
+BOSAT
+10 10 3 /
+1  1  1 /
+/
+
+-- PRESSURE IN INJECTION AND PRODUCTION CELL
+BPR
+10 10 3 /
+1  1  1 /
+/
+
+SCHEDULE ===============================================================
+-------- THE SCHEDULE SECTION DEFINES THE OPERATIONS TO BE SIMULATED
+------------------------------------------------------------------------
+-- CONTROLS ON OUTPUT AT EACH REPORT TIME
+RPTSCHED
+   1   0   1   1   0     0   4   2   2   0     0   2   0   0   0
+   0   0   0   0   0     0   0   0   0   0     0   0   0   0   0
+   0   0   0   0   0     0   0   0   1   0     0   0   0   0   0  /
+
+
+--IMPES
+-- 1.0 1.0 10000.0 /
+
+-- SET 'NO RESOLUTION' OPTION
+--DRSDT
+-- 0 /
+
+-- SET INITIAL TIME STEP TO 1 DAY AND MAXIMUM TO 6 MONTHS
+TUNING
+1  182.5  /
+1.0 0.5 1.0E-6 /
+/
+
+-- WELL SPECIFICATION DATA
+--
+--     WELL   GROUP LOCATION  BHP   PI
+--     NAME   NAME    I  J   DEPTH DEFN
+WELSPECS
+    'PRODUCER' 'G'   10 10    8400 'OIL'  /
+    'INJECTOR' 'G'    1  1    8335 'GAS'  /
+/
+
+-- COMPLETION SPECIFICATION DATA
+--
+--     WELL     -LOCATION- OPEN/ SAT CONN  WELL
+--     NAME     I  J K1 K2 SHUT  TAB FACT  DIAM
+COMPDAT
+    'PRODUCER'  10 10 3  3 'OPEN' 0   -1   0.5  /
+    'INJECTOR'   1  1 1  1 'OPEN' 1   -1   0.5  /
+  /
+
+-- PRODUCTION WELL CONTROLS
+--
+--      WELL     OPEN/  CNTL   OIL  WATER   GAS  LIQU   RES   BHP
+--      NAME     SHUT   MODE  RATE   RATE  RATE  RATE  RATE
+WCONPROD
+     'PRODUCER' 'OPEN' 'ORAT' 20000  4*                      1000 /
+  /
+-- WCONPROD
+--      'PRODUCER' 'OPEN' 'BHP' 5*                      1000 /
+--   /
+
+-- INJECTION WELL CONTROLS
+--
+--      WELL     INJ   OPEN/  CNTL    FLOW
+--      NAME    TYPE   SHUT   MODE    RATE
+-- WCONINJ
+--     'INJECTOR' 'GAS' 'OPEN' 'RATE'  100000  /
+WCONINJE
+     'INJECTOR' 'GAS' 'OPEN' 'RATE' 100000 100000 50000/
+  /
+
+--  YEAR 1
+
+TSTEP
+--0.2343    0.1393    0.1840    0.2189    0.2235
+--1.0 4.0 2*5.0 6*5.0 10*25.0
+1.0 14.0 13*25.0
+  /
+
+TSTEP
+   25.0
+  /
+
+-- YEAR 2
+
+TSTEP
+  13*20.0 7*13.0
+  /
+
+TSTEP
+    14.0
+  /
+
+-- YEAR 3
+
+TSTEP
+ 17*10.0
+  /
+
+TSTEP
+  12.5
+  /
+
+-- 912.50 --> 1000.0
+
+TSTEP
+  8.5 16*5.0
+  /
+
+TSTEP
+  5.0
+  /
+
+-- 1000.0  -->  1100.0
+
+TSTEP
+  19*5.0
+  /
+
+TSTEP
+  5.0
+  /
+
+-- 1100.0  -->  1200.0
+
+TSTEP
+  19*5.0
+  /
+
+TSTEP
+  5.0
+  /
+
+
+TSTEP
+10.0 /
+
+END     ================================================================


### PR DESCRIPTION
This is a version of the SPE1 deck which excerts the "pseudo thermal" features of the `flow` simulator, cf OPM/opm-autodiff#324. The simulator is able to fully run the deck, but I did not check whether the PVT parameters I came up with are very meaningful and if the result produced by `flow` is reasonable. Also, don't try to feed this to Eclipse if you're not up for a fight.
