### PR TITLE
Changed the output folder in the run.param file

### DIFF
--- a/polymer_test_suit/simple2D/run.param
+++ b/polymer_test_suit/simple2D/run.param
@@ -1,5 +1,5 @@
 deck_filename=2D_THREEPHASE_POLY_HETER.DATA
-output_dir=opm-simulation-reference
+output_dir=opm-simulation
 pvt_tab_size=-1
 sat_tab_size=-1
 threephase_model=gwseg


### PR DESCRIPTION
To avoid overwriting the reference case that is in the repo, the output folder in the param file is renamed to opm-simulation.
