### PR TITLE
Norne: switch back to pid+iteration as time step control.

### DIFF
--- a/norne/norne_default.param
+++ b/norne/norne_default.param
@@ -39,9 +39,11 @@ cpr_use_amg=true
 // true if adaptive time stepping scheme is used
 timestep.adaptive=true
 // time step control scheme = iterationcount | pid | pid+iteration (default)
-timestep.control=iterationcount
+timestep.control=pid+iteration
+// PID control tolerance (default = 1e-3)
+timestep.control.tol=4e-5
 // target iteration = sum of all linear iterations over all newton iterations per timestep
-timestep.control.targetiteration=15
+timestep.control.targetiteration=8
 // factor by which time step can at most grow in each step
 timestep.control.maxgrowth=1.6
 // verbosity of adaptive time stepping

--- a/norne/plotwells.sh
+++ b/norne/plotwells.sh
@@ -105,23 +105,25 @@ done
 
 WELLTEX=$OUTPUT.tex
 
-echo "\\documentclass{article}" > $WELLTEX
-echo "\\usepackage{graphicx}" >> $WELLTEX
-echo "\\setlength{\\hoffset}{0cm}" >> $WELLTEX
-echo "\\setlength{\\topmargin}{0.5cm}" >> $WELLTEX
-echo "\\setlength{\\headsep}{0cm}" >> $WELLTEX
-echo "\\setlength{\\headheight}{0cm}" >> $WELLTEX
-echo "\\setlength{\\textheight}{23cm}" >> $WELLTEX
-echo "\\setlength{\\textwidth}{15.5cm}" >> $WELLTEX
-echo "\\setlength{\\evensidemargin}{0.48cm}" >> $WELLTEX
-echo "\\setlength{\\oddsidemargin}{0.0cm}" >> $WELLTEX
-echo "\\begin{document}" >> $WELLTEX
-echo "\\input{$WELLLISTEX}" >> $WELLTEX
-echo "\\end{document}" >> $WELLTEX
+TEXFILE="
+\\documentclass{article}
+\\usepackage{graphicx}
+\\setlength{\\hoffset}{0cm}
+\\setlength{\\topmargin}{0.5cm}
+\\setlength{\\headsep}{0cm}
+\\setlength{\\headheight}{0cm}
+\\setlength{\\textheight}{23cm}
+\\setlength{\\textwidth}{15.5cm}
+\\setlength{\\evensidemargin}{0.48cm}
+\\setlength{\\oddsidemargin}{0.0cm}
+\\begin{document}
+\\input{$WELLLISTEX}
+\\end{document}"
 
-latex --interaction=nonstopmode $OUTPUT
-latex --interaction=nonstopmode $OUTPUT
-dvipdf $OUTPUT
+echo $TEXFILE | latex --interaction=nonstopmode
+echo $TEXFILE | latex --interaction=nonstopmode
+
+dvipdf article $OUTPUT.pdf
 
 # remove temporary files
 rm -f $WELLLISTEX


### PR DESCRIPTION
New default parameters that should run Norne in decent time. 

Also, the plot script was fixed to hopefully work on eppler systems.  
