### PR TITLE
Added parameters to improve (PRESSURE) results when compared to Eclipse.

### DIFF
--- a/spe1/spe1deck.xml
+++ b/spe1/spe1deck.xml
@@ -3,5 +3,6 @@
 <ParameterGroup name="root">
   <Parameter name="deck_filename" type="file" value="SPE1DECK.DATA"/>
   <Parameter name="output_dir" type="string" value="opm-simulation"/>
+  <Parameter name="tolerance_mb" type="double" value="1.0e-07"/>
 </ParameterGroup>
 

--- a/spe3/spe3.xml
+++ b/spe3/spe3.xml
@@ -3,4 +3,5 @@
 <ParameterGroup name="root">
   <Parameter name="deck_filename" type="file" value="SPE3_MODIFIED.DATA"/>
   <Parameter name="output_dir" type="string" value="opm-simulation"/>
+  <Parameter name="timestep.adaptive" type="bool" value="false" />
 </ParameterGroup>

--- a/spe9/spe9deck.xml
+++ b/spe9/spe9deck.xml
@@ -3,5 +3,7 @@
 <ParameterGroup name="root">
   <Parameter name="deck_filename" type="file" value="SPE9.DATA"/>
   <Parameter name="output_dir" type="string" value="opm-simulation"/>
+  <Parameter name="timestep.adaptive" type="bool" value="false" />
+  <Parameter name="cpr_use_amg" type="bool" value="false" />
 </ParameterGroup>
 


### PR DESCRIPTION
After f007bf561cb07e4a0cb10534661be647eb13ecef the default parameters were changed, and the results for SPE tests diverged a bit more from Eclipse. This commit brings them back to where they were.
