### PR TITLE
Updated SPE parameter files to match the defaults prior to 22th of April...

### DIFF
--- a/spe1/spe1deck.xml
+++ b/spe1/spe1deck.xml
@@ -3,6 +3,15 @@
 <ParameterGroup name="root">
   <Parameter name="deck_filename" type="file" value="SPE1DECK.DATA"/>
   <Parameter name="output_dir" type="string" value="opm-simulation"/>
+  <Parameter name="cpr_solver_tol" type="double" value="1.0e-4"/>
+  <Parameter name="cpr_max_elliptic_iter" type="int" value="5000"/>
+  <Parameter name="cpr_use_amg" type="bool" value="false"/>
+  <Parameter name="min_iter" type="int" value="0"/>
   <Parameter name="tolerance_mb" type="double" value="1.0e-07"/>
+  <Parameter name="tolerance_cnv" type="double" value="1.0e-3"/>
+  <Parameter name="newton_use_gmres" type="bool" value="true"/>
+  <Parameter name="linear_solver_reduction" type="double" value="1.0e-3"/>
+  <Parameter name="linear_solver_maxiter" type="int" value="150"/>
+  <Parameter name="timestep.adaptive" type="bool" value="false"/>
 </ParameterGroup>
 

--- a/spe3/spe3.xml
+++ b/spe3/spe3.xml
@@ -3,5 +3,14 @@
 <ParameterGroup name="root">
   <Parameter name="deck_filename" type="file" value="SPE3_MODIFIED.DATA"/>
   <Parameter name="output_dir" type="string" value="opm-simulation"/>
-  <Parameter name="timestep.adaptive" type="bool" value="false" />
+  <Parameter name="cpr_solver_tol" type="double" value="1.0e-4"/>
+  <Parameter name="cpr_max_elliptic_iter" type="int" value="5000"/>
+  <Parameter name="cpr_use_amg" type="bool" value="false"/>
+  <Parameter name="min_iter" type="int" value="0"/>
+  <Parameter name="tolerance_mb" type="double" value="1.0e-07"/>
+  <Parameter name="tolerance_cnv" type="double" value="1.0e-3"/>
+  <Parameter name="newton_use_gmres" type="bool" value="true"/>
+  <Parameter name="linear_solver_reduction" type="double" value="1.0e-3"/>
+  <Parameter name="linear_solver_maxiter" type="int" value="150"/>
+  <Parameter name="timestep.adaptive" type="bool" value="false"/>
 </ParameterGroup>

--- a/spe9/spe9deck.xml
+++ b/spe9/spe9deck.xml
@@ -3,7 +3,15 @@
 <ParameterGroup name="root">
   <Parameter name="deck_filename" type="file" value="SPE9.DATA"/>
   <Parameter name="output_dir" type="string" value="opm-simulation"/>
-  <Parameter name="timestep.adaptive" type="bool" value="false" />
-  <Parameter name="cpr_use_amg" type="bool" value="false" />
+  <Parameter name="cpr_solver_tol" type="double" value="1.0e-4"/>
+  <Parameter name="cpr_max_elliptic_iter" type="int" value="5000"/>
+  <Parameter name="cpr_use_amg" type="bool" value="false"/>
+  <Parameter name="min_iter" type="int" value="0"/>
+  <Parameter name="tolerance_mb" type="double" value="1.0e-07"/>
+  <Parameter name="tolerance_cnv" type="double" value="1.0e-3"/>
+  <Parameter name="newton_use_gmres" type="bool" value="true"/>
+  <Parameter name="linear_solver_reduction" type="double" value="1.0e-3"/>
+  <Parameter name="linear_solver_maxiter" type="int" value="150"/>
+  <Parameter name="timestep.adaptive" type="bool" value="false"/>
 </ParameterGroup>
 


### PR DESCRIPTION
... 2015.

Commit f007bf561cb07e4a0cb10534661be647eb13ecef changed default parameters.

With this commit, the parameters reflect the defaults prior to this, except for max_residual_allowed and tolerance_wells (they were depending on double::max and Opm::unit::day.

The values in output restart files are with this commit back to what they were (by a small margin), for PRESSURE, SGAS and SWAT
