### PR TITLE
Keep using old well residual tolerance.

### DIFF
--- a/polymer_test_suite/simple2D/run.param
+++ b/polymer_test_suite/simple2D/run.param
@@ -8,3 +8,4 @@ dp_max_rel=0.2
 ds_max=0.05
 max_iter=100
 use_cpr=false
+tolerance_wells=0.5


### PR DESCRIPTION
This is necessary to keep the case just as before, with identical results. With too tight tolerance it will even fail half-way through.
