### PR TITLE
changed data in TOPS keyword

### DIFF
--- a/spe1_new/SPE1CASE1.DATA
+++ b/spe1_new/SPE1CASE1.DATA
@@ -66,7 +66,7 @@ DZ
 
 TOPS
 -- The depth of the top of each grid block
-	100*8325 100*8345 100*8375 /
+	100*8325 /
 
 PORO
 -- Constant porosity of 0.3 throughout all 300 grid cells

--- a/spe1_new/SPE1CASE2.DATA
+++ b/spe1_new/SPE1CASE2.DATA
@@ -66,7 +66,7 @@ DZ
 
 TOPS
 -- The depth of the top of each grid block
-	100*8325 100*8345 100*8375 /
+	100*8325 /
 
 PORO
 -- Constant porosity of 0.3 throughout all 300 grid cells


### PR DESCRIPTION
Made changes in TOPS keyword in GRID section. Now, only the depth of the top layer is specified. This change is necessary in order for Eclipse and Flow to produce the same result.
