### PR TITLE
changed data in TOPS keyword for SPE3

### DIFF
--- a/spe3_new/SPE3CASE1.DATA
+++ b/spe3_new/SPE3CASE1.DATA
@@ -68,7 +68,8 @@ DZ
 
 TOPS
 -- The depth of the top of each grid block
-	81*7315 81*7345 81*7375 81*7425 /
+--	81*7315 81*7345 81*7375 81*7425 /
+	81*7315 /	
 
 PORO
 -- Constant porosity of 0.3 throughout all 324 grid cells

--- a/spe3_new/SPE3CASE2.DATA
+++ b/spe3_new/SPE3CASE2.DATA
@@ -68,7 +68,8 @@ DZ
 
 TOPS
 -- The depth of the top of each grid block
-	81*7315 81*7345 81*7375 81*7425 /
+--	81*7315 81*7345 81*7375 81*7425 /
+	81*7315 /
 
 PORO
 -- Constant porosity of 0.3 throughout all 324 grid cells


### PR DESCRIPTION
By only specifying the depth of the top layer in keyword TOPS, the discrepancy between Eclipse and Flow is reduced.  This is especially noticeable in graph of WWPR:PROD. 
