### PR TITLE
Make 2D polymer deck valid under strict parsing

### DIFF
--- a/polymer_test_suite/simple2D/2D_THREEPHASE_POLY_HETER.DATA
+++ b/polymer_test_suite/simple2D/2D_THREEPHASE_POLY_HETER.DATA
@@ -1046,7 +1046,6 @@ NOECHO
 
 INCLUDE
  'POLY.inc' /
- /
 
 ---------------------------------------------------------------------------------
 SOLUTION
@@ -1071,12 +1070,10 @@ FIP=3  SWAT /
 SUMMARY
 
 ALL
-/
 
 --INCLUDE
 -- 'SUMMARY.inc' /
 
---/
 SCHEDULE
 
 OPTIONS
@@ -1085,7 +1082,6 @@ OPTIONS
 
 RPTSCHED
  POLYMER PRES SGAS SOIL SWAT /
-/
 
 RPTRST
 VELOCITY
@@ -1153,5 +1149,4 @@ TSTEP
 34*25
 20*100.0
 60*100.0
-/
 /


### PR DESCRIPTION
This commit removes the deck's stray keyword terminators (slash characters) in order that the deck be valid under module opm-parser's default [`ParserMode`](https://github.com/OPM/opm-parser/blob/master/opm/parser/eclipse/Parser/ParseMode.hpp) (strict).
