### PR TITLE
Add test cases for Todd-Longstaff miscibility model

### DIFF
--- a/solvent_test_suite/SPE1CASE2_SOLVENT_MISC_TL.DATA
+++ b/solvent_test_suite/SPE1CASE2_SOLVENT_MISC_TL.DATA
@@ -1,0 +1,538 @@
+-- This reservoir simulation deck is made available under the Open Database
+-- License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in
+-- individual contents of the database are licensed under the Database Contents
+-- License: http://opendatacommons.org/licenses/dbcl/1.0/
+
+-- Copyright (C) 2015 Statoil
+
+-- This simulation is based on the data given in 
+-- 'Comparison of Solutions to a Three-Dimensional
+-- Black-Oil Reservoir Simulation Problem' by Aziz S. Odeh,
+-- Journal of Petroleum Technology, January 1981
+
+-- Modified by Tor Harald Sandve, IRIS 2015 to work as a test case 
+-- for the Solvent model.
+-- The following changes are made: 
+-- (1) use family II input (SWFN, SGFN, SOF3)
+-- (2) add solvent data
+-- (3) add miscibility data 
+-- (4) add Todd-Longstaff parameters
+---------------------------------------------------------------------------
+------------------------ SPE1 - CASE 1 ------------------------------------
+---------------------------------------------------------------------------
+
+RUNSPEC
+-- -------------------------------------------------------------------------
+
+TITLE
+   SPE1 - CASE 1
+
+DIMENS
+   10 10 3 /
+
+-- The number of equilibration regions is inferred from the EQLDIMS
+-- keyword.
+EQLDIMS
+/
+
+-- The number of PVTW tables is inferred from the TABDIMS keyword;
+-- when no data is included in the keyword the default values are used.
+TABDIMS
+/
+
+OIL
+GAS
+WATER
+DISGAS
+
+SOLVENT
+
+MISCIBLE
+ 1 20 /
+
+-- As seen from figure 4 in Odeh, GOR is increasing with time,
+-- which means that dissolved gas is present
+
+FIELD
+
+START
+   1 'JAN' 2015 /
+
+WELLDIMS
+-- Item 1: maximum number of wells in the model
+-- 	   - there are two wells in the problem; injector and producer
+-- Item 2: maximum number of grid blocks connected to any one well
+-- 	   - must be one as the wells are located at specific grid blocks
+-- Item 3: maximum number of groups in the model
+-- 	   - we are dealing with only one 'group'
+-- Item 4: maximum number of wells in any one group
+-- 	   - there must be two wells in a group as there are two wells in total
+   2 3 1 2 /
+
+UNIFOUT
+
+GRID
+-- -------------------------------------------------------------------------
+NOECHO
+
+DX 
+-- There are in total 300 cells with length 1000ft in x-direction	
+   	300*1000 /
+DY
+-- There are in total 300 cells with length 1000ft in y-direction	
+	300*1000 /
+DZ
+-- The layers are 20, 30 and 50 ft thick, in each layer there are 100 cells
+	100*20 100*30 100*50 /
+
+TOPS
+-- The depth of the top of each grid block
+	100*8325 /
+
+PORO
+-- Constant porosity of 0.3 throughout all 300 grid cells
+   	300*0.3 /
+
+PERMX
+-- The layers have perm. 500mD, 50mD and 200mD, respectively.
+	100*500 100*50 100*200 /
+
+PERMY
+-- Equal to PERMX
+	100*500 100*50 100*200 /
+
+PERMZ
+-- Cannot find perm. in z-direction in Odeh's paper
+-- For the time being, we will assume PERMZ equal to PERMX and PERMY:
+	100*500 100*50 100*200 /
+ECHO
+
+PROPS
+-- -------------------------------------------------------------------------
+
+PVTW
+-- Item 1: pressure reference (psia)
+-- Item 2: water FVF (rb per bbl or rb per stb)
+-- Item 3: water compressibility (psi^{-1})
+-- Item 4: water viscosity (cp)
+-- Item 5: water 'viscosibility' (psi^{-1})
+
+-- Using values from Norne:
+-- In METRIC units:
+-- 	277.0 1.038 4.67E-5 0.318 0.0 /
+-- In FIELD units:
+    	4017.55 1.038 3.22E-6 0.318 0.0 /
+
+ROCK
+-- Item 1: reference pressure (psia)
+-- Item 2: rock compressibility (psi^{-1})
+
+-- Using values from table 1 in Odeh:
+	14.7 3E-6 /
+
+SWFN
+-- Column 1: water saturation
+--   	     - this has been set to (almost) equally spaced values from 0.12 to 1
+-- Column 2: water relative permeability
+--   	     - generated from the Corey-type approx. formula
+--	       the coeffisient is set to 10e-5, S_{orw}=0 and S_{wi}=0.12
+-- Column 3: water-oil capillary pressure (psi) 
+
+0.12	0    		 	0
+0.18	4.64876033057851E-008	0
+0.24	0.000000186		0
+0.3	4.18388429752066E-007	0
+0.36	7.43801652892562E-007	0
+0.42	1.16219008264463E-006	0
+0.48	1.67355371900826E-006	0
+0.54	2.27789256198347E-006	0
+0.6	2.97520661157025E-006	0
+0.66	3.7654958677686E-006	0
+0.72	4.64876033057851E-006	0
+0.78	0.000005625		0
+0.84	6.69421487603306E-006	0
+0.91	8.05914256198347E-006	0
+1	0.00001			0 /
+
+
+SGFN
+-- Column 1: gas saturation
+-- Column 2: gas relative permeability
+-- Column 3: oil-gas capillary pressure (psi)
+-- 	     - stated to be zero in Odeh's paper
+
+-- Values in column 1-2 are taken from table 3 in Odeh's paper:
+0	0	0
+0.001	0	0
+0.02	0	0
+0.05	0.005	0
+0.12	0.025	0
+0.2	0.075	0
+0.25	0.125	0
+0.3	0.190	0
+0.4	0.410	0
+0.45	0.60	0
+0.5	0.72	0
+0.6	0.87	0
+0.7	0.94	0
+0.85	0.98	0 
+0.88	0.984	0 /
+--1.00	1.0	0 /
+-- Warning from Eclipse: first sat. value in SWOF + last sat. value in SGOF
+-- 	   		 must not be greater than 1, but Eclipse still runs
+-- Flow needs the sum to be excactly 1 so I added a row with gas sat. =  0.88
+-- The corresponding krg value was estimated by assuming linear rel. between
+-- gas sat. and krw. between gas sat. 0.85 and 1.00 (the last two values given)
+
+-- Column 1: oil saturation
+-- Column 2: oil relative permeability when oil, gas and connate water are present
+-- Column 3: oil relative permeability when only oil and water are present
+--  - we will use the same values for column 2 and column 3 as given
+--  in Odeh's paper. This is not really correct, but since only the first 
+--  two values are of importance, this does not really matter
+
+SOF3
+--  SOIL     KROW     KROG
+    0        0        0
+    0.03     0	      0 	
+    0.18     0        0
+    0.28     0.0001   0.0001
+    0.38     0.001    0.001
+    0.43     0.01     0.01
+    0.48     0.021    0.021
+    0.58     0.09     0.09
+    0.63     0.2      0.2
+    0.68     0.35     0.35
+    0.76     0.7      0.7
+    0.83     0.98     0.98
+    0.86     0.997    0.997
+    0.879    1        1
+    0.88     1        1    /
+
+SOF2
+--  SOIL     KROW     
+    0        0        
+    0.03     0       	
+    0.18     0       
+    0.28     0.0001   
+    0.38     0.001    
+    0.43     0.01     
+    0.48     0.021    
+    0.58     0.09     
+    0.63     0.2      
+    0.68     0.35     
+    0.76     0.7      
+    0.83     0.98     
+    0.86     0.997   
+    0.879    1        
+    0.88     1        /
+
+SSFN 
+ 0.0 0.0 0.0
+ 0.5 0.4 0.8 
+ 1.0 1.0 1.0
+/
+
+MISC
+ 0.0 0.0
+ 0.1 0.9
+-- 0.01 0.5
+-- 0.1 0.9
+ 1.0 1.0 /
+
+--MSFN
+-- 0.0 0.0 1.0
+-- 1.0 1.0 0.0 /
+
+DENSITY
+-- Density (lb per ft³) at surface cond. of 
+-- oil, water and gas, respectively (in that order)
+
+-- Using values from Norne:
+-- In METRIC units:
+--      859.5 1033.0 0.854 /
+-- In FIELD units:
+      	53.66 64.49 0.0533 /
+
+SDENSITY
+ 0.1 /
+
+TLMIXPAR
+ 0.7 0.5  /
+
+PVDG
+-- Column 1: gas phase pressure (psia)
+-- Column 2: gas formation volume factor (rb per Mscf)
+-- 	     - in Odeh's paper the units are said to be given in rb per bbl, 
+-- 	       but this is assumed to be a mistake: FVF-values in Odeh's paper 
+--	       are given in rb per scf, not rb per bbl. This will be in 
+--	       agreement with conventions
+-- Column 3: gas viscosity (cP)
+
+-- Using values from lower right table in Odeh's table 2:
+14.700	166.666	0.008000
+264.70	12.0930	0.009600
+514.70	6.27400	0.011200
+1014.7	3.19700	0.014000
+2014.7	1.61400	0.018900
+2514.7	1.29400	0.020800
+3014.7	1.08000	0.022800
+4014.7	0.81100	0.026800
+5014.7	0.64900	0.030900
+9014.7	0.38600	0.047000 /
+
+PVDS
+14.700	83.666	0.08000
+264.70	6.0930	0.09600
+514.70	3.27400	0.11200
+1014.7	1.69700	0.14000
+2014.7	0.81400	0.18900
+2514.7	0.69400	0.20800
+3014.7	0.58000	0.22800
+4014.7	0.41100	0.26800
+5014.7	0.34900	0.30900
+9014.7	0.18600	0.47000 /
+ 
+PVTO
+-- Column 1: dissolved gas-oil ratio (Mscf per stb)
+-- Column 2: bubble point pressure (psia)
+-- Column 3: oil FVF for saturated oil (rb per stb)
+-- Column 4: oil viscosity for saturated oil (cP)
+
+-- Use values from top left table in Odeh's table 2:
+0.0010	14.7	1.0620	1.0400 /
+0.0905	264.7	1.1500	0.9750 /
+0.1800	514.7	1.2070	0.9100 /
+0.3710	1014.7	1.2950	0.8300 /
+0.6360	2014.7	1.4350	0.6950 /
+0.7750	2514.7	1.5000	0.6410 /
+0.9300	3014.7	1.5650	0.5940 /
+1.2700	4014.7	1.6950	0.5100 
+	9014.7	1.5790	0.7400 /
+1.6180	5014.7	1.8270	0.4490 
+	9014.7	1.7370	0.6310 /	
+-- It is required to enter data for undersaturated oil for the highest GOR
+-- (i.e. the last row) in the PVTO table.
+-- In order to fulfill this requirement, values for oil FVF and viscosity
+-- at 9014.7psia and GOR=1.618 for undersaturated oil have been approximated:
+-- It has been assumed that there is a linear relation between the GOR
+-- and the FVF when keeping the pressure constant at 9014.7psia.
+-- From Odeh we know that (at 9014.7psia) the FVF is 2.357 at GOR=2.984
+-- for saturated oil and that the FVF is 1.579 at GOR=1.27 for undersaturated oil,
+-- so it is possible to use the assumption described above. 
+-- An equivalent approximation for the viscosity has been used.
+/
+	
+-- It is required to enter data for undersaturated oil for the highest GOR
+-- (i.e. the last row) in the PVTO table.
+-- In order to fulfill this requirement, values for oil FVF and viscosity
+-- at 9014.7psia and GOR=1.618 for undersaturated oil have been approximated:
+-- It has been assumed that there is a linear relation between the GOR
+-- and the FVF when keeping the pressure constant at 9014.7psia.
+-- From Odeh we know that (at 9014.7psia) the FVF is 2.357 at GOR=2.984
+-- for saturated oil and that the FVF is 1.579 at GOR=1.27 for undersaturated oil,
+-- so it is possible to use the assumption described above. 
+-- An equivalent approximation for the viscosity has been used.
+/
+
+SOLUTION
+-- -------------------------------------------------------------------------
+
+EQUIL
+-- Item 1: datum depth (ft)
+-- Item 2: pressure at datum depth (psia)
+-- 	   - Odeh's table 1 says that initial reservoir pressure is 
+-- 	     4800 psi at 8400ft, which explains choice of item 1 and 2
+-- Item 3: depth of water-oil contact (ft)
+-- 	   - chosen to be directly under the reservoir
+-- Item 4: oil-water capillary pressure at the water oil contact (psi)
+-- 	   - given to be 0 in Odeh's paper
+-- Item 5: depth of gas-oil contact (ft)
+-- 	   - chosen to be directly above the reservoir
+-- Item 6: gas-oil capillary pressure at gas-oil contact (psi)
+-- 	   - given to be 0 in Odeh's paper
+-- Item 7: RSVD-table
+-- Item 8: RVVD-table
+-- Item 9: Set to 0 as this is the only value supported by OPM
+
+-- Item #: 1 2    3    4 5    6 7 8 9
+	8400 4800 8450 0 8300 0 1 0 0 /
+
+RSVD
+-- Dissolved GOR is initially constant with depth through the reservoir.
+-- The reason is that the initial reservoir pressure given is higher 
+---than the bubble point presssure of 4014.7psia, meaning that there is no 
+-- free gas initially present.
+	8300 1.270
+	8450 1.270 /
+
+SUMMARY
+-- -------------------------------------------------------------------------	 
+
+-- 1a) Oil rate vs time
+FOPR
+-- Field Oil Production Rate
+
+-- 1b) GOR vs time
+WGOR
+-- Well Gas-Oil Ratio
+   'PROD'
+/
+-- Using FGOR instead of WGOR:PROD results in the same graph
+FGOR
+
+-- 2a) Pressures of the cell where the injector and producer are located
+BPR
+1  1  1 /
+10 10 3 /
+/
+
+-- 2b) Gas saturation at grid points given in Odeh's paper
+BGSAT
+1  1  1 /
+1  1  2 /
+1  1  3 /
+10 1  1 /
+10 1  2 /
+10 1  3 /
+10 10 1 /
+10 10 2 /
+10 10 3 /
+/
+
+BOKR
+1 1 1/
+/
+
+BWKR
+1 1 1/
+/
+
+-- In order to compare Eclipse with Flow:
+WBHP
+  'INJ'
+  'PROD'
+/
+WGIR
+  'INJ'
+  'PROD'
+/
+WGIT
+  'INJ'
+  'PROD'
+/
+WGPR
+  'INJ'
+  'PROD'
+/
+WGPT
+  'INJ'
+  'PROD'
+/
+WOIR
+  'INJ'
+  'PROD'
+/
+WOIT
+  'INJ'
+  'PROD'
+/
+WOPR
+  'INJ'
+  'PROD'
+/
+WOPT
+  'INJ'
+  'PROD'
+/
+WWIR
+  'INJ'
+  'PROD'
+/
+WWIT
+  'INJ'
+  'PROD'
+/
+WWPR
+  'INJ'
+  'PROD'
+/
+WWPT
+  'INJ'
+  'PROD'
+/
+
+SCHEDULE
+-- -------------------------------------------------------------------------
+RPTSCHED
+	'PRES' 'SGAS' 'SSOL' 'SWAT' 'SOIL' 'WELLS' 'KRN' 'KRG' 'KRO' 'KRW'/
+
+RPTRST
+	'BASIC=1' /
+
+
+-- If no resolution (i.e. case 1), the two following lines must be added:
+--DRSDT
+-- 0 /
+-- if DRSDT is set to 0, GOR cannot rise and free gas does not 
+-- dissolve in undersaturated oil -> constant bubble point pressure
+
+WELSPECS
+-- Item #: 1	 2	3	4	5	 6
+	'PROD'	'G1'	10	10	8400	'OIL' /
+	'INJ'	'G1'	1	1	8335	'GAS' /
+/
+-- Coordinates in item 3-4 are retrieved from Odeh's figure 1 and 2
+-- Note that the depth at the midpoint of the well grid blocks
+-- has been used as reference depth for bottom hole pressure in item 5
+
+COMPDAT
+-- Item #: 1	2	3	4	5	6	7	8	9
+	'PROD'	10	10	3	3	'OPEN'	1*	1*	0.5 /
+	'INJ'	1	1	1	1	'OPEN'	1*	1*	0.5 /
+/
+-- Coordinates in item 2-5 are retreived from Odeh's figure 1 and 2 
+-- Item 9 is the well bore internal diameter, 
+-- the radius is given to be 0.25ft in Odeh's paper
+
+
+WCONPROD
+-- Item #:1	2      3     4	   5  9
+	'PROD' 'OPEN' 'ORAT' 20000 4* 100 /
+/
+-- It is stated in Odeh's paper that the maximum oil prod. rate
+-- is 20 000stb per day which explains the choice of value in item 4.
+-- The items > 4 are defaulted with the exception of item  9,
+-- the BHP lower limit, which is given to be 1000psia in Odeh's paper
+
+WCONINJE
+-- Item #:1	 2	 3	 4	5      6  7
+	'INJ'	'GAS'	'OPEN'	'RATE'	100000 1* 901400 /
+/
+
+WSOLVENT
+'INJ'  1.0/
+/
+
+-- Stated in Odeh that gas inj. rate (item 5) is 100MMscf per day
+-- BHP upper limit (item 7) should not be exceeding the highest
+-- pressure in the PVT table=9014.7psia (default is 100 000psia)
+
+
+TSTEP
+--Advance the simulater once a month for TEN years:
+31 28 31 30 31 30 31 31 30 31 30 31 
+31 28 31 30 31 30 31 31 30 31 30 31 
+31 28 31 30 31 30 31 31 30 31 30 31 
+31 28 31 30 31 30 31 31 30 31 30 31 
+31 28 31 30 31 30 31 31 30 31 30 31 
+31 28 31 30 31 30 31 31 30 31 30 31 
+31 28 31 30 31 30 31 31 30 31 30 31 
+31 28 31 30 31 30 31 31 30 31 30 31 
+31 28 31 30 31 30 31 31 30 31 30 31 
+31 28 31 30 31 30 31 31 30 31 30 31 /
+
+--Advance the simulator once a year for TEN years:
+--10*365 /
+
+END

--- a/solvent_test_suite/SPE9_CP_SOLVENT_CO2_MISC_TL.DATA
+++ b/solvent_test_suite/SPE9_CP_SOLVENT_CO2_MISC_TL.DATA
@@ -1,0 +1,663 @@
+-- This reservoir simulation deck is made available under the Open Database
+-- License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in
+-- individual contents of the database are licensed under the Database Contents
+-- License: http://opendatacommons.org/licenses/dbcl/1.0/
+
+-- Copyright (C) 2015 Statoil
+
+-- This simulation is based on the data given in 
+-- 'Ninth SPE Comparative Solution Project:
+-- A Reexamination of Black-Oil Simulation',
+-- by J.E. Killough,
+-- Journal of Petroleum Technology, 1995
+
+-- A dataset from one of the participants was supplied to the 
+-- participants of SPE 9. Some of the information in this
+-- dataset has been used here as well. 
+
+-- The origin of information or data used in this simulation is 
+-- specified in comments. This does not include data whose origin
+-- should be obvious to the reader.
+
+
+
+-- NOTE: Changes should be made to the data entered in keywords PVTW and ROCK
+-- 	 See comments under these keywords
+
+-- Modified by Tor Harald Sandve, IRIS 2015 to work as a test case 
+-- for the Solvent model.
+-- The following changes are made: 
+-- (1) use family II input (SWFN, SGFN, SOF3)
+-- (2) add solvent data
+-- (3) use CO2 properties (pvt) for the solvent
+-- (4) add miscibility data 
+-- (5) add Todd-Longstaff parameters
+
+
+----------------------------------------------------------------
+------------------------- SPE 9 --------------------------------
+----------------------------------------------------------------
+
+RUNSPEC
+
+TITLE
+	SPE 9
+
+DIMENS
+	24 25 15 /
+OIL
+WATER
+GAS
+DISGAS
+
+SOLVENT
+
+MISCIBLE
+ 1 20 /
+
+-- From figure 7 in Killough's paper it is evident 
+-- that GOR is increasing with time, meaning
+-- that there must be dissolved gas present
+
+FIELD
+
+START
+	1 'JAN' 2015 /
+
+WELLDIMS
+-- Item 1: maximum number of wells in the model
+-- 	   - there are 26 wells in SPE9; 1 injector and 25 producers
+-- Item 2: maximum number of grid blocks connected to any one well
+-- 	   - the injector is completed in 5 layers
+-- Item 3: maximum number of groups in the model
+-- 	   - only one group in model
+-- Item 4: maximum number of wells in any one group
+-- 	   - this can definitetly not be more than 26 
+	26 5 1 26 /
+TABDIMS
+-- The number of rows in SWOF exceeds the default maximum,
+-- so item 3 in this keyword must be changed:
+	1* 1* 40 40/
+
+EQLDIMS
+/
+
+--NSTACK
+--	25 /
+-- Eclipse suggested increasing NSTACK
+
+UNIFOUT
+
+
+GRID
+-- Killough says 'the grid was in conventional rectangular 
+-- coordinates without corner point geometry or local grid refinements'
+
+
+NOECHO
+
+INIT
+
+INCLUDE
+	'../spe9/SPE9.GRDECL' /
+
+PORO
+-- Porosity in each level is contant
+-- The values are specified in table 1 in Killough's paper
+   	600*0.087
+	600*0.097
+	600*0.111
+	600*0.16
+	600*0.13
+	600*0.17
+	600*0.17
+	600*0.08
+	600*0.14
+	600*0.13
+	600*0.12
+	600*0.105
+	600*0.12
+	600*0.116
+	600*0.157 /
+
+-- PERMX, PERMY & PERMZ
+INCLUDE
+	'../spe9/PERMVALUES.DATA' /
+
+ECHO
+
+PROPS
+
+PVTW
+-- Item 1: pressure reference (psia)
+-- Item 2: water FVF (rb per bbl or rb per stb)
+-- Item 3: water compressibility (psi^{-1})
+-- Item 4: water viscosity (cp)
+-- Item 5: water 'viscosibility' (psi^{-1})
+
+-- Item 1 and 2 are stated in Killough, and item 5 is assumed = zero
+-- Item 3 and 4 are taken from SPE2
+  	3600 1.0034 3e-6 0.96 0 /
+
+--NOTE:
+--   a)	It is not explicitly stated in Killough that it is okay to use SPE2-values here. 
+--   b)	I am not 100% sure if the given compressibility value is at ref. pres. 3600psia.
+--   c)	Item 3 and 4 can probably be explained on the basis of Killough's dataset. In 
+-- 	order to do that I need info about keywords in VIP
+
+ROCK
+-- Item 1: reference pressure (psia)
+-- Item 2: rock compressibility (psi^{-1})
+
+-- Using values from SPE2:
+   	3600 4e-6 /
+
+-- NOTE:
+--   a) It is not explicitly stated in Killough that it is okay to use SPE2-values here.
+--   a) I am not 100% sure if the given compressibility value is at 3600psia.
+--   b) 'Comp. Methods for Multiphase Flow in Porous Media' states
+--      that rock compr. is 1e-6 inverse psi. This is probably correct, as
+--   	I think this is based on Killough's dataset - to be sure, I need 
+-- 	more info about keywords in VIP.
+
+DENSITY
+-- Density (lb per ft³) at surface cond. of 
+-- oil, water and gas, respectively (in that order)
+
+-- The values for oil and water are given by Killough to
+-- be 0.7206 and 1.0095 gm per cc, or equivalently 
+-- 44.9856 and 63.0210 lb per ft³
+
+-- A gas density of 0.07039 lb per ft³ was calculated using formula at 
+-- petrowiki.org/Calculating_gas_properties:
+-- (28.967*Specific gravity*pressure)/(Z-factor*gas constant*temperature) 
+-- with the values given in Killough's table 2 at 14.7 psia (1 atm).
+-- A temperature of 15C=59F was also used in the above formula.
+	44.9856 63.0210 0.07039 /
+
+SDENSITY
+  0.1249 /
+
+	
+PVTO
+-- Column 1: dissolved gas-oil ratio (Mscf per stb)
+-- Column 2: bubble point pressure for oil (psia)
+-- Column 3: oil FVF for saturated oil (rb per stb)
+-- Column 4: oil viscosity for saturated oil (cP)
+
+-- Using values from table 2 in Killough's paper:
+0  	 14.7	 1	 1.20 /
+0.165	 400	 1.0120	 1.17 /
+0.335	 800	 1.0255	 1.14 /
+0.500	 1200	 1.0380	 1.11 /
+0.665	 1600	 1.0510	 1.08 /
+0.828	 2000	 1.0630	 1.06 /
+0.985	 2400	 1.0750	 1.03 /
+1.130	 2800	 1.0870	 1.00 /
+1.270	 3200	 1.0985	 0.98 /
+1.390	 3600	 1.1100	 0.95 /
+1.500	 4000	 1.1200	 0.94 
+         4600    1.1089  0.94 /
+--	 5000	 1.1189	 0.94 /
+/
+-- Comment in regards to the last row in PVTO:
+--   Killough says that 'at 1000psi above the saturation
+--   pressure the Bo is 0.999 times that of the Bo at Psat'
+--   which means that the FVF (i.e. Bo) at 4600psia is 0.999*0.1100=1.1089
+--   Killough also says that 'the oil viscosity does not 
+--   increase with increasing pressure in undersaturated conditions'
+--   which explains why the oil viscosity is 0.94.
+
+PVDG
+-- Column 1: gas phase pressure (psia)
+-- Column 2: gas formation volume factor (rb per Mscf)
+-- 	     - This is calculated using formula:
+--	       Bg=5.03676*Z*temperature(R)/pressure(psia) rb/Mscf
+--	       where a constant temperature=100F=559.67R has been used because
+--	       that is the initial reservoir temperature according to Killough's paper
+--	       The above formula is retrieved from 
+--	       petrowiki.org/Gas_formation_volume_factor_and_density
+-- Column 3: gas viscosity (cP)
+
+-- Using values from table 2 in Killough's paper:
+   14.7	 191.7443 	0.0125
+   400    5.8979	0.0130
+   800    2.9493	0.0135
+   1200	  1.9594	0.0140
+   1600	  1.4695	0.0145
+   2000	  1.1797	0.0150
+   2400	  0.9796	0.0155
+   2800	  0.8397	0.0160
+   3200	  0.7398	0.0165
+   3600	  0.6498	0.0170
+   4000	  0.5849	0.0175 /
+
+PVDS
+  1160.302    0.9789    0.0265
+  1266.663    0.5809    0.0460
+  1373.024    0.5278    0.0529
+  1479.385    0.5026    0.0572
+  1585.746    0.4861    0.0605
+  1692.107    0.4738    0.0632
+  1798.468    0.4641    0.0656
+  1904.829    0.4560    0.0678
+  2011.190    0.4491    0.0698
+  2117.551    0.4431    0.0716
+  2223.912    0.4378    0.0733
+  2330.273    0.4330    0.0750
+  2436.634    0.4287    0.0765
+  2542.995    0.4248    0.0780
+  2649.356    0.4211    0.0795
+  2755.717    0.4178    0.0808
+  2862.078    0.4146    0.0822
+  2968.439    0.4117    0.0835
+  3074.800    0.4089    0.0847
+  3181.161    0.4063    0.0860
+  3287.522    0.4039    0.0872
+  3393.883    0.4016    0.0883
+  3500.244    0.3993    0.0895
+  3606.605    0.3972    0.0906
+  3712.966    0.3952    0.0917
+  3819.327    0.3933    0.0928
+  3925.688    0.3914    0.0939
+  4032.049    0.3897    0.0949
+  4138.410    0.3880    0.0960
+  4244.771    0.3863    0.0970
+  4351.132    0.3847    0.0980 /
+
+SGFN
+-- Column 1: gas saturation
+-- Column 2: gas relative permeability
+-- Column 3: oil relative permeability when oil, gas and connate water are present
+-- Column 4: corresponding oil-gas capillary pressure (psi)
+
+-- Using values from table 3 in Killough's paper:
+0  	  0	     0
+0.04	  0	     0.2
+0.1	  0.022	     0.5
+0.2	  0.1	     1.0
+0.3	  0.24	     1.5
+0.4	  0.34	     2.0
+0.5	  0.42	     2.5
+0.6	  0.5	     3.0
+0.7	  0.8125     3.5
+0.84891	  0.9635     3.82 /
+--0.88491 1	     		3.9 /
+-- Comment in regards to the last row in SGOF:
+--   Changes have been made so that the last row
+--   is at a gas sat. of Sg=1-Swc=1-0.151090=0.84891
+--   The Krg and Pcog values corresponding to Sg=0.84891
+--   have been approximated by assuming linear relation between
+--   Krg/Pcog and Sg in the range Sg=0.7 to Sg=0.88491
+
+SWFN
+-- Column 1: water saturation
+-- Column 2: water relative permeability
+-- Column 3: oil relative permeability when only oil and water are present
+-- Column 4: corresponding water-oil capillary pressure (psi) 
+
+-- These values are taken from Killough's dataset:
+0.151090     0.0     400.0
+0.151230     0.0     359.190
+0.151740     0.0     257.920
+0.152460     0.0     186.310
+0.156470     0.0     79.060
+0.165850     0.0     40.010
+0.178350     0.0     27.930
+0.203350 0.000010    20.400
+0.253350 0.000030    15.550
+0.350000 0.000280    11.655
+0.352000 0.002292    8.720
+0.354000 0.004304    5.947
+0.356000 0.006316    3.317
+0.358000 0.008328    1.165
+0.360000 0.010340    0.463
+0.364395 0.015548    -0.499
+0.368790 0.020756    -1.139
+0.370000 0.022190    -1.194
+0.380000 0.035890    -1.547
+0.400000 0.069530    -1.604
+0.433450 0.087900    -1.710
+0.461390 0.104910    -1.780
+0.489320 0.123290    -1.860
+0.517250 0.143030    -1.930
+0.573120 0.186590    -2.070
+0.601060 0.210380    -2.130
+0.656930 0.261900    -2.260
+0.712800 0.318650    -2.380
+0.811110 0.430920    -2.600
+0.881490 0.490000    -2.750 /
+
+SOF3
+-- SOIL KROW KROG
+    0.1185         0         0
+    0.1889    0.0000    0.0000
+    0.2872    0.0016    0.0016
+    0.3431    0.0059    0.0059
+    0.3989    0.0162    0.0162
+    0.4269    0.0246    0.0246
+    0.4828    0.0511    0.0511
+    0.5107    0.0705    0.0705
+    0.5386    0.0950    0.0950
+    0.5665    0.1253    0.1253
+    0.6000    0.1714    0.1714
+    0.6200    0.4350    0.4350
+    0.6300    0.5680    0.5680
+    0.6312    0.5840    0.5840
+    0.6356    0.6423    0.6423
+    0.6400    0.7005    0.7005
+    0.6420    0.7264    0.7264
+    0.6440    0.7524    0.7524
+    0.6460    0.7783    0.7783
+    0.6480    0.8043    0.8043
+    0.6500    0.8302    0.8302
+    0.7467    0.9437    0.9437
+    0.7966    0.9788    0.9788
+    0.8216    0.9916    0.9916
+    0.8341    0.9963    0.9963
+    0.8435    0.9995    0.9995
+    0.8475    0.9999    0.9999
+    0.8483    0.9999    0.9999
+    0.8488    1.0000    1.0000
+    0.8489    1.0000    1.0000 /
+
+SOF2
+-- SOIL KROW 
+    0.1185         0         
+    0.1889    0.0000    
+    0.2872    0.0016    
+    0.3431    0.0059    
+    0.3989    0.0162    
+    0.4269    0.0246    
+    0.4828    0.0511    
+    0.5107    0.0705    
+    0.5386    0.0950    
+    0.5665    0.1253    
+    0.6000    0.1714    
+    0.6200    0.4350    
+    0.6300    0.5680    
+    0.6312    0.5840    
+    0.6356    0.6423    
+    0.6400    0.7005    
+    0.6420    0.7264    
+    0.6440    0.7524    
+    0.6460    0.7783    
+    0.6480    0.8043    
+    0.6500    0.8302    
+    0.7467    0.9437    
+    0.7966    0.9788    
+    0.8216    0.9916    
+    0.8341    0.9963    
+    0.8435    0.9995    
+    0.8475    0.9999    
+    0.8483    0.9999    
+    0.8488    1.0000    
+    0.8489    1.0000    /
+
+SSFN 
+ 0.0 0.0 0.0
+ 0.5 0.4 0.8 
+ 1.0 1.0 1.0
+/
+
+MISC
+ 0.0 0.0
+ 0.1 1.0
+ 1.0 1.0 /
+
+TLMIXPAR
+ 0.7 0.3  /
+
+SOLUTION
+
+EQUIL
+-- Item 1: datum depth (ft)
+-- Item 2: pressure at datum depth (psia)
+-- 	   - Killough says initial oil phase pressure is
+--	   - 3600psia at depth 9035ft
+-- Item 3: depth of water-oil contact (ft)
+-- 	   - Given to be 9950 ft in Killough's paper
+-- Item 4: oil-water capillary pressure at the water oil contact (psi)
+-- 	   - Given to be 0 in Killough's dataset
+-- 	   - 0 in SPE2
+-- Item 5: depth of gas-oil contact (ft)
+--	   - 8800ft in Killough's dataset
+-- Item 6: gas-oil capillary pressure at gas-oil contact (psi)
+-- 	   - Given to be 0 in Killough's dataset
+-- 	   - 0 in SPE2
+-- Item 7: RSVD-table
+-- Item 8: RVVD-table
+-- Item 9: OPM only supports item 9 equal to zero.
+
+--      #: 1    2    3    4 5    6 7 8 9
+   	   9035 3600 9950 0 8800 0 1 0 0 /
+
+
+RSVD
+-- The initial oil phase pressure is given to be 3600psia, at
+-- which the GOR is 1.39 Mscf per stb according to Killough's table 2.
+-- Since there is no free gas initially present*, the oil
+-- phase (with dissolved gas) must initially have a constant GOR as
+-- a function of depth through the reservoir (at the given pressure)
+	8800 1.39
+	9950 1.39 /
+-- *)
+--   This is explicitly stated in Killough's paper.
+--   Note that the initial oil phase pressure is the same as
+--   the saturation (bubble point) pressure of the oil.
+--   This should also imply that there is no free gas initially present.
+--   Since there is no free gas initially present, the gas-oil
+--   contact should lie above the reservoir, which it does (EQUIL, item 5)
+
+--RPTSOL
+-- RESTART=1 SGAS SOIL SWAT /
+ 
+SUMMARY
+
+
+-- Killough's figure 7:
+FGOR
+-- Killough's figure 8:
+FOPR
+-- Killough's figure 9:
+FGPR
+-- Killough's figure 10:
+FWPR
+-- Killough's figure 11:
+BPR
+ 1 1 1 /
+/
+-- Killough's figure 12:
+BGSAT
+ 1 13 1 /
+/
+-- Killough's figure 13:
+BWSAT
+ 10 25 15 /
+/
+-- Killough's figure 14:
+--WWIR
+-- 'INJE1' /
+-- Killough's figure 15:
+--WOPR
+-- 'PRODU21' /
+
+-- In order to compare Eclipse with Flow:
+WBHP
+/
+WGIR
+/
+--WGIT
+--/
+WGPR
+/
+WGPT
+/
+WOIR
+/
+--WOIT
+--/
+WOPR
+/
+WOPT
+/
+WWIR
+/
+--WWIT
+--/
+WWPR
+/
+WWPT
+/
+
+SCHEDULE
+
+--RPTRST
+--	'BASIC=2' /
+
+RPTSCHED
+ WELLS=2 /
+
+TUNING
+ 4.0  60.0  0.1    /
+                   /
+  12 2 15          /
+
+
+WELSPECS
+-- Column 3: I-value of well head or heel
+-- Column 4: J-value of well head or heel
+-- 	     - these coordinates are listed in Killough's dataset
+-- Column 5: ref. depth of BHP (ft)
+--           - stated in the middle of the top perforated cell
+-- 	     - not anymore stated to be 9110ft in Killough
+-- Column 6: preferred phase for well
+-- 	     - should be water for injector and oil for producers
+-- Column 7: drainage radius for calc. of productivity or 
+--           injectivity indices (ft)
+--	     - stated to be 60ft in Killough
+
+-- #: 1	       2   3  4 5	 6	7  
+ 'INJE1 '  'P'   24 25  9110 'GAS'	60   /
+ 'PRODU2 '  'P'   5  1  9110 'OIL'	60   /
+ 'PRODU3 '  'P'   8  2  9110 'OIL'	60   /
+ 'PRODU4 '  'P'  11  3  9110 'OIL'	60   /
+ 'PRODU5 '  'P'  10  4  9110 'OIL'	60   /
+ 'PRODU6 '  'P'  12  5  9110 'OIL'	60   /
+ 'PRODU7 '  'P'   4  6  9110 'OIL'	60   /
+ 'PRODU8 '  'P'   8  7  9110 'OIL'	60   /
+ 'PRODU9 '  'P'  14  8  9110 'OIL'	60   /
+ 'PRODU10'  'P'  11  9  9110 'OIL'	60   /
+ 'PRODU11'  'P'  12 10  9110 'OIL'	60   /
+ 'PRODU12'  'P'  10 11  9110 'OIL'	60   /
+ 'PRODU13'  'P'   5 12  9110 'OIL'	60   /
+ 'PRODU14'  'P'   8 13  9110 'OIL'	60   /
+ 'PRODU15'  'P'  11 14  9110 'OIL'	60   /
+ 'PRODU16'  'P'  13 15  9110 'OIL'	60   /
+ 'PRODU17'  'P'  15 16  9110 'OIL'	60   /
+ 'PRODU18'  'P'  11 17  9110 'OIL'	60   /
+ 'PRODU19'  'P'  12 18  9110 'OIL'	60   /
+ 'PRODU20'  'P'   5 19  9110 'OIL'	60   /
+ 'PRODU21'  'P'   8 20  9110 'OIL'	60   /
+ 'PRODU22'  'P'  11 21  9110 'OIL'	60   /
+ 'PRODU23'  'P'  15 22  9110 'OIL'	60   /
+ 'PRODU24'  'P'  12 23  9110 'OIL'	60   /
+ 'PRODU25'  'P'  10 24  9110 'OIL'	60   /
+ 'PRODU26'  'P'  17 25  9110 'OIL'	60   /
+/
+
+COMPDAT
+-- Column 2: I-value of connecting grid block
+-- Column 3: J-value of connecting grid block
+-- Column 4: K-value of upper connecting grid block
+-- Column 5: K-value of lower connecting grid block
+-- 	     - these coordinates are listed in Killough's dataset
+-- Column 9: well bore diameter
+-- 	     - Killough says radius is 0.5ft
+
+--Item 8 must be entered in order to get a match between Eclipse and Flow
+--No match if item 8 is defaulted
+
+-- #: 1	      	     2  3	 4    5	  6	7	8	9 
+
+     'INJE1'        24 25	11   15	'OPEN'	1*	1*	1 /
+     'PRODU2'        5  1	 2    4	'OPEN'	1*	1*	1 /
+     'PRODU3'        8  2	 2    4	'OPEN'	1*	1*	1 /
+     'PRODU4'       11  3	 2    4	'OPEN'	1*	1*	1 /
+     'PRODU5'       10  4	 2    4	'OPEN'	1*	1*	1 /
+     'PRODU6'       12  5	 2    4	'OPEN'	1*	1*	1 /
+     'PRODU7'        4  6	 2    4	'OPEN'	1*	1*	1 /
+     'PRODU8'        8  7	 2    4	'OPEN'	1*	1*	1 /
+     'PRODU9'       14  8	 2    4	'OPEN'	1*	1*	1 /
+     'PRODU10'      11  9	 2    4	'OPEN'	1*	1*	1 /
+     'PRODU11'      12 10	 2    4	'OPEN'	1*	1*	1 /
+     'PRODU12'      10 11	 2    4	'OPEN'	1*	1*	1 /
+     'PRODU13'       5 12	 2    4	'OPEN'	1*	1*	1 /
+     'PRODU14'       8 13	 2    4	'OPEN'	1*	1*	1 /
+     'PRODU15'      11 14	 2    4	'OPEN'	1*	1*	1 /
+     'PRODU16'      13 15	 2    4	'OPEN'	1*	1*	1 /
+     'PRODU17'      15 16	 2    4	'OPEN'	1*	1*	1 /
+     'PRODU18'      11 17	 2    4	'OPEN'	1*	1*	1 /
+     'PRODU19'      12 18	 2    4	'OPEN'	1*	1*	1 /
+     'PRODU20'       5 19	 2    4	'OPEN'	1*	1*	1 /
+     'PRODU21'       8 20	 2    4	'OPEN'	1*	1*	1 /
+     'PRODU22'      11 21	 2    4	'OPEN'	1*	1*	1 /
+     'PRODU23'      15 22	 2    4	'OPEN'	1*	1*	1 /
+     'PRODU24'      12 23	 2    4	'OPEN'	1*	1*	1 /
+     'PRODU25'      10 24	 2    4	'OPEN'	1*	1*	1 /
+     'PRODU26'      17 25	 2    4	'OPEN'	1*	1*	1 /
+/
+
+WCONINJE
+-- Killough says the water injector is set to a max rate of
+-- 5000 STBW per D with a max BHP of 4000psia at a reference 
+-- depth of 9110ft subsea:
+--   #:  1	    2       3      4     5       7
+	'INJE1' 'GAS' 'OPEN' 'RATE' 5000 1* 10000 /
+/
+
+WCONPROD
+-- Killough says the max oil rate for all producers is set to 
+-- 1500 STBO per D at time zero and that the min flowing BHP
+-- is set to 1000psia (with a ref. depth of 9110ft
+-- for this pressure in all wells):
+--   #:   1           2      3     4       9
+     	 'PRODU*' 'OPEN' 'ORAT' 1500 4* 1000  /
+-- Here, the wildcard '*' has been used to indicate that this applies
+-- to all producers; PRODU1-PRODU25.
+/
+
+WSOLVENT
+'INJE1'  1.0/
+/
+
+TSTEP
+30*10 /
+
+-- At 300 days, the max oil rate for all producers is lowered
+-- to 100 STBO per D:
+WCONPROD
+--   #:   1           2      3     4      9
+     	 'PRODU*' 'OPEN' 'ORAT' 100 4* 1000 /
+/
+
+
+TSTEP
+6*10 /
+
+-- At 360 days, the max oil rate for all producers is changed
+-- back to 1500 STBO per D:
+WCONPROD
+--   #:   1           2      3     4       9
+     	 'PRODU*' 'OPEN' 'ORAT' 1500 4* 1000 /
+/
+
+
+TSTEP
+54*10 /
+-- End of simulation at 900 days
+
+END
+
+
+


### PR DESCRIPTION
Test cases used for the solvent model with miscibility effects. 
The tests cases are based on SPE1CASE2_SOLVENT and SPE9_CP_CO2 where miscibility keywords and Todd-Longstaff keywords are added. 
