### PR TITLE
using interleaved solver for 3D polymer case.

### DIFF
--- a/polymer_test_suite/3D_plyshlog/case-no-polymer/run.param
+++ b/polymer_test_suite/3D_plyshlog/case-no-polymer/run.param
@@ -7,4 +7,4 @@ drs_max_rel=0.2
 dp_max_rel=0.2
 ds_max=0.05
 max_iter=15
-solver_approach=direct
+solver_approach=interleaved

--- a/polymer_test_suite/3D_plyshlog/case-no-shear/run.param
+++ b/polymer_test_suite/3D_plyshlog/case-no-shear/run.param
@@ -7,4 +7,4 @@ drs_max_rel=0.2
 dp_max_rel=0.2
 ds_max=0.05
 max_iter=15
-solver_approach=direct
+solver_approach=interleaved

--- a/polymer_test_suite/3D_plyshlog/case-shear-thickening/run.param
+++ b/polymer_test_suite/3D_plyshlog/case-shear-thickening/run.param
@@ -7,4 +7,4 @@ drs_max_rel=0.2
 dp_max_rel=0.2
 ds_max=0.05
 max_iter=15
-solver_approach=direct
+solver_approach=interleaved

--- a/polymer_test_suite/3D_plyshlog/case-shear-thinning/run.param
+++ b/polymer_test_suite/3D_plyshlog/case-shear-thinning/run.param
@@ -7,4 +7,4 @@ drs_max_rel=0.2
 dp_max_rel=0.2
 ds_max=0.05
 max_iter=15
-solver_approach=direct
+solver_approach=interleaved


### PR DESCRIPTION
For 3D polymer cases, interleaved solver is used for better efficiency. 

3D polymer cases can be run by `flow_polymer DATAfile`, while just keep `run.param`s for now. 
