### PR TITLE
Remove temporary .gnu files from plotwells.sh

### DIFF
--- a/norne/plotwells.sh
+++ b/norne/plotwells.sh
@@ -118,5 +118,8 @@ dvipdf article $OUTPUT.pdf
 # remove temporary files
 rm -f $WELLLISTEX
 rm -f $PLOTFILE
+for DIR in $DIRS; do
+  rm -f $DIR/*.gnu
+done
 rm -f $WELLTEX $OUTPUT.aux $OUTPUT.log $OUTPUT.dvi
 find . -name "well-*.eps" -exec rm {} \;


### PR DESCRIPTION
After running plotwells.sh there are a lot .gnu files left over in the directories. This commit removes them at the end of the script.
