### PR TITLE
Update well filtering.

### DIFF
--- a/norne/plotwells.sh
+++ b/norne/plotwells.sh
@@ -19,7 +19,7 @@ done
 
 WELLS=
 for W in $ALLWELLS; do
-  WELL=`echo $W | grep WBHP`
+  WELL=`echo $W | grep WBHP | grep -v WBHPH`
 
   if [ "$ALLOPTS" == "" ]; then
     OPT=`echo $W | cut -d ":" -f 1`


### PR DESCRIPTION
The new summaries contain WBHPH in addition to WBHP, causing the script to find each well twice.

This just filters out the WBHPH.
