### PR TITLE
Fixed well names in Summary section.

### DIFF
--- a/solvent_test_suite/SPE5.BASE
+++ b/solvent_test_suite/SPE5.BASE
@@ -330,79 +330,66 @@ SUMMARY
 WBHP
   'INJW'
   'INJG'
-  'INJ'
   'PROD'
 /
 WGIR
   'INJW'
   'INJG'
-  'INJ'
   'PROD'
 /
 WGIT
   'INJW'
   'INJG'
-  'INJ'
   'PROD'
 /
 WGPR
   'INJW'
   'INJG'
-  'INJ'
   'PROD'
 /
 WGPT
   'INJW'
   'INJG'
-  'INJ'
   'PROD'
 /
 WOIR
   'INJW'
   'INJG'
-  'INJ'
   'PROD'
 /
 WOIT
   'INJW'
   'INJG'
-  'INJ'
   'PROD'
 /
 WOPR
   'INJW'
   'INJG'
-  'INJ'
   'PROD'
 /
 WOPT
   'INJW'
   'INJG'
-  'INJ'
   'PROD'
 /
 WWIR
-   'INJW'
+  'INJW'
   'INJG'
-  'INJ'
   'PROD'
 /
 WWIT
   'INJW'
   'INJG'
-  'INJ'
   'PROD'
 /
 WWPR
   'INJW'
   'INJG'
-  'INJ'
   'PROD'
 /
 WWPT
   'INJW'
   'INJG'
-  'INJ'
   'PROD'
 /
 

--- a/spe10model2/SPE10_MODEL2.DATA
+++ b/spe10model2/SPE10_MODEL2.DATA
@@ -182,24 +182,24 @@ WBHP
 /
 
 WOPR
-   'PRO1'
-   'PRO2'
-   'PRO3'
-   'PRO4'
+   'P1'
+   'P2'
+   'P3'
+   'P4'
 /
 
 WWCT
-   'PRO1'
-   'PRO2'
-   'PRO3'
-   'PRO4'
+   'P1'
+   'P2'
+   'P3'
+   'P4'
 /
 
 WOPT
-   'PRO1'
-   'PRO2'
-   'PRO3'
-   'PRO4'
+   'P1'
+   'P2'
+   'P3'
+   'P4'
 /
 
 


### PR DESCRIPTION
Some well names entered explicitly in the Summary section did not match
the well names given by WELSPECS.

Currently the parser/output internalizes the `SUMMARY` section, and you get the summary output which is actually queried for. With the last commit of: https://github.com/OPM/opm-parser/pull/863 the parser will check that well names given in the summary section agree with those given by `WELSPECS`; for the two decks affected in this PR there was a mismatch - the `SUMMARY` section has been updated to match the `WELSPECS`.
