### PR TITLE
Added travis integration to opm-data.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,31 @@
+language: cpp
+
+compiler:
+  - gcc
+
+addons:
+  apt:
+    sources:
+      - boost-latest
+      - ubuntu-toolchain-r-test
+    packages:
+      - libboost1.55-all-dev
+      - gcc-4.8
+      - g++-4.8
+      - gfortran-4.8
+      - liblapack-dev
+      - libgmp3-dev
+      - libsuitesparse-dev
+      - libeigen3-dev
+
+before_script:
+    - export CXX="g++-4.8" CC="gcc-4.8" FC="gfortran-4.8"
+    - cd ..
+    - git clone https://github.com/OPM/opm-common.git
+    - opm-common/travis/clone-opm.sh opm-data
+    - opm-common/travis/build-prereqs.sh
+    
+
+script: opm-common/travis/build-and-test.sh opm-common
+
+


### PR DESCRIPTION
This PR will build and test the full downstream chain. To protect against accidentally merging data changes which break the tests.

I addition to the `.travis.yml` file added in this PR Travis must also be granted access to the repo.
