### PR TITLE
Remove extra INJ in summary output

### DIFF
--- a/solvent_test_suite/SPE5.BASE
+++ b/solvent_test_suite/SPE5.BASE
@@ -330,79 +330,66 @@ SUMMARY
 WBHP
   'INJW'
   'INJG'
-  'INJ'
   'PROD'
 /
 WGIR
   'INJW'
   'INJG'
-  'INJ'
   'PROD'
 /
 WGIT
   'INJW'
   'INJG'
-  'INJ'
   'PROD'
 /
 WGPR
   'INJW'
   'INJG'
-  'INJ'
   'PROD'
 /
 WGPT
   'INJW'
   'INJG'
-  'INJ'
   'PROD'
 /
 WOIR
   'INJW'
   'INJG'
-  'INJ'
   'PROD'
 /
 WOIT
   'INJW'
   'INJG'
-  'INJ'
   'PROD'
 /
 WOPR
   'INJW'
   'INJG'
-  'INJ'
   'PROD'
 /
 WOPT
   'INJW'
   'INJG'
-  'INJ'
   'PROD'
 /
 WWIR
-   'INJW'
+  'INJW'
   'INJG'
-  'INJ'
   'PROD'
 /
 WWIT
   'INJW'
   'INJG'
-  'INJ'
   'PROD'
 /
 WWPR
   'INJW'
   'INJG'
-  'INJ'
   'PROD'
 /
 WWPT
   'INJW'
   'INJG'
-  'INJ'
   'PROD'
 /
 


### PR DESCRIPTION
The new output does not like output of non-existing wells. This PR removes them. 
