### PR TITLE
Update restart deck as well to match.

### DIFF
--- a/spe1/SPE1CASE2_ACTNUM_RESTART.DATA
+++ b/spe1/SPE1CASE2_ACTNUM_RESTART.DATA
@@ -436,6 +436,6 @@ WCONINJE
 
 TSTEP
 --Advance the simulater once a month for ONE year:
-31 28 31 30 31 30 31 31 30 31 30 31 /
+1 3 9 18 28 31 30 31 30 31 31 30 31 30 31 /
 
 END


### PR DESCRIPTION
The restart version of the deck was not updated in #151, leading to test failures.

This makes the time step sequences identical again.